### PR TITLE
fix: scale factor computation example on macos

### DIFF
--- a/sandbox/Chickensoft.Platform.SandboxRef/src/Main.cs
+++ b/sandbox/Chickensoft.Platform.SandboxRef/src/Main.cs
@@ -36,7 +36,9 @@ public partial class Main : Control {
     var godotRes = DisplayServer.ScreenGetSize(window.CurrentScreen);
     var windowSize = window.Size;
     // To convert from Godot to monitor scale
-    var correctionFactor = monitorScale / systemScale;
+    var correctionFactor = OS.HasFeature("macos")
+      ? (float)resolution.Y / godotRes.Y // macos
+      : monitorScale / systemScale; // windows
 
     var themeScale = (float)resolution.Y / ThemeDesignSize.Y;
 


### PR DESCRIPTION
just updates the example project to make scaling behave independently of actual scale factor on macos the same way it is done on windows (cross-platform consistency)