### PR TITLE
chore: remove GDExtension :'(

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,145 +14,145 @@ on:
           - patch
 
 jobs:
-  build-macos:
-    runs-on: macos-latest
-    env:
-      MAC_APP_DISTRIBUTION_BASE64: ${{ secrets.MAC_APP_DISTRIBUTION }}
-      KEYCHAIN_PASSWORD: 1234
-    steps:
-      - name: 🧾 Checkout
-        uses: actions/checkout@v4
-        with:
-          lfs: true
-          submodules: "recursive"
-          fetch-depth: 0 # So we can get all tags.
+  # build-macos:
+  #   runs-on: macos-latest
+  #   env:
+  #     MAC_APP_DISTRIBUTION_BASE64: ${{ secrets.MAC_APP_DISTRIBUTION }}
+  #     KEYCHAIN_PASSWORD: 1234
+  #   steps:
+  #     - name: 🧾 Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         lfs: true
+  #         submodules: "recursive"
+  #         fetch-depth: 0 # So we can get all tags.
 
-      - name: 🔑 Setup Codesigning
-        run: |
-          # GitHub has a guide for just this.
-          # https://docs.github.com/en/actions/use-cases-and-examples/deploying/installing-an-apple-certificate-on-macos-runners-for-xcode-development
+  #     - name: 🔑 Setup Codesigning
+  #       run: |
+  #         # GitHub has a guide for just this.
+  #         # https://docs.github.com/en/actions/use-cases-and-examples/deploying/installing-an-apple-certificate-on-macos-runners-for-xcode-development
 
-          # create variables
-          CERTIFICATE_PATH=$RUNNER_TEMP/mac_app_distribution.p12
-          KEYCHAIN_PATH=$RUNNER_TEMP/codesigning.keychain-db
+  #         # create variables
+  #         CERTIFICATE_PATH=$RUNNER_TEMP/mac_app_distribution.p12
+  #         KEYCHAIN_PATH=$RUNNER_TEMP/codesigning.keychain-db
 
-          echo -n "$MAC_APP_DISTRIBUTION_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+  #         echo -n "$MAC_APP_DISTRIBUTION_BASE64" | base64 --decode -o $CERTIFICATE_PATH
 
-          # create temporary keychain
-          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+  #         # create temporary keychain
+  #         security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+  #         security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+  #         security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
 
-          # import certificate to keychain
-          security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH
+  #         # import certificate to keychain
+  #         security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+  #         security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+  #         security list-keychain -d user -s $KEYCHAIN_PATH
 
-          # save keychain path for later steps
-          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> $GITHUB_ENV
+  #         # save keychain path for later steps
+  #         echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> $GITHUB_ENV
 
-          # save certificate for later steps
-          CERT=$(security find-identity -p codesigning -v $KEYCHAIN_PATH | grep -oE '".*"' | tr -d '"')
-          echo "Codesigning certificate: $CERT"
-          echo "CERT=$CERT" >> $GITHUB_ENV
+  #         # save certificate for later steps
+  #         CERT=$(security find-identity -p codesigning -v $KEYCHAIN_PATH | grep -oE '".*"' | tr -d '"')
+  #         echo "Codesigning certificate: $CERT"
+  #         echo "CERT=$CERT" >> $GITHUB_ENV
 
-      - uses: actions/setup-dotnet@v4
-        name: 💽 Setup .NET SDK
-        with:
-          # Use the .NET SDK from global.json in the root of the repository.
-          global-json-file: global.json
+  #     - uses: actions/setup-dotnet@v4
+  #       name: 💽 Setup .NET SDK
+  #       with:
+  #         # Use the .NET SDK from global.json in the root of the repository.
+  #         global-json-file: global.json
 
-      - name: 🌍 Install dependencies
-        run: dotnet restore
+  #     - name: 🌍 Install dependencies
+  #       run: dotnet restore
 
-      - name: 📦 Build for macOS
-        run: |
-          chmod +x ./build.sh
-          ./build.sh macos
+  #     - name: 📦 Build for macOS
+  #       run: |
+  #         chmod +x ./build.sh
+  #         ./build.sh macos
 
-      - name: 🔐 Codesign Dylibs
-        run: |
-          codesign --sign "$CERT" --options runtime \
-            addons/platform/builds/macos/Platform.osx.arm64.dylib
-          codesign --sign "$CERT" --options runtime \
-            addons/platform/builds/macos/Platform.osx.x64.dylib
+  #     - name: 🔐 Codesign Dylibs
+  #       run: |
+  #         codesign --sign "$CERT" --options runtime \
+  #           addons/platform/builds/macos/Platform.osx.arm64.dylib
+  #         codesign --sign "$CERT" --options runtime \
+  #           addons/platform/builds/macos/Platform.osx.x64.dylib
 
-      - name: 🧐 Verify Codesigning
-        run: |
-          codesign --verify --verbose=4 \
-            addons/platform/builds/macos/Platform.osx.arm64.dylib
-          codesign --verify --verbose=4 \
-            addons/platform/builds/macos/Platform.osx.x64.dylib
+  #     - name: 🧐 Verify Codesigning
+  #       run: |
+  #         codesign --verify --verbose=4 \
+  #           addons/platform/builds/macos/Platform.osx.arm64.dylib
+  #         codesign --verify --verbose=4 \
+  #           addons/platform/builds/macos/Platform.osx.x64.dylib
 
-      - name: ⬆️ Upload macOS artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: macos-artifacts
-          path: ./addons/platform/builds/macos
+  #     - name: ⬆️ Upload macOS artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: macos-artifacts
+  #         path: ./addons/platform/builds/macos
 
-  build-windows:
-    runs-on: windows-latest
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - name: 🧾 Checkout
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GH_BASIC }}
-          lfs: true
-          submodules: "recursive"
-          fetch-depth: 0 # So we can get all tags.
+  # build-windows:
+  #   runs-on: windows-latest
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   steps:
+  #     - name: 🧾 Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         token: ${{ secrets.GH_BASIC }}
+  #         lfs: true
+  #         submodules: "recursive"
+  #         fetch-depth: 0 # So we can get all tags.
 
-      - uses: actions/setup-dotnet@v4
-        name: 💽 Setup .NET SDK
-        with:
-          # Use the .NET SDK from global.json in the root of the repository.
-          global-json-file: global.json
+  #     - uses: actions/setup-dotnet@v4
+  #       name: 💽 Setup .NET SDK
+  #       with:
+  #         # Use the .NET SDK from global.json in the root of the repository.
+  #         global-json-file: global.json
 
-      - name: 🌍 Install dependencies
-        run: dotnet restore
+  #     - name: 🌍 Install dependencies
+  #       run: dotnet restore
 
-      - name: 📦 Build for Windows
-        run: |
-          chmod +x ./build.sh
-          ./build.sh windows
+  #     - name: 📦 Build for Windows
+  #       run: |
+  #         chmod +x ./build.sh
+  #         ./build.sh windows
 
-      - name: ⬆️ Upload Windows artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-artifacts
-          path: ./addons/platform/builds/windows
+  #     - name: ⬆️ Upload Windows artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: windows-artifacts
+  #         path: ./addons/platform/builds/windows
 
-  build-linux:
-    runs-on: ubuntu-latest
-    steps:
-      - name: 🧾 Checkout
-        uses: actions/checkout@v4
-        with:
-          lfs: true
-          submodules: "recursive"
-          fetch-depth: 0 # So we can get all tags.
+  # build-linux:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: 🧾 Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         lfs: true
+  #         submodules: "recursive"
+  #         fetch-depth: 0 # So we can get all tags.
 
-      - uses: actions/setup-dotnet@v4
-        name: 💽 Setup .NET SDK
-        with:
-          # Use the .NET SDK from global.json in the root of the repository.
-          global-json-file: global.json
+  #     - uses: actions/setup-dotnet@v4
+  #       name: 💽 Setup .NET SDK
+  #       with:
+  #         # Use the .NET SDK from global.json in the root of the repository.
+  #         global-json-file: global.json
 
-      - name: 🌍 Install dependencies
-        run: dotnet restore
+  #     - name: 🌍 Install dependencies
+  #       run: dotnet restore
 
-      - name: 📦 Build for Linux
-        run: |
-          chmod +x ./build.sh
-          ./build.sh linux
+  #     - name: 📦 Build for Linux
+  #       run: |
+  #         chmod +x ./build.sh
+  #         ./build.sh linux
 
-      - name: ⬆️ Upload Linux artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: linux-artifacts
-          path: ./addons/platform/builds/linux
+  #     - name: ⬆️ Upload Linux artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: linux-artifacts
+  #         path: ./addons/platform/builds/linux
 
   # Project is shipped as GDExtension for GDScript users, and also as a nuget
   # package for C# scripting users.
@@ -219,48 +219,48 @@ jobs:
           name: nuget-artifact
           path: ${{ steps.package-path.outputs.package }}
 
-  consolidate-artifacts:
-    runs-on: ubuntu-latest
-    needs:
-      - build-macos
-      - build-windows
-      - build-linux
-    steps:
-      - name: 🧾 Checkout
-        uses: actions/checkout@v4
-        with:
-          lfs: true
-          submodules: "recursive"
-          fetch-depth: 0 # So we can get all tags.
+  # consolidate-artifacts:
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - build-macos
+  #     - build-windows
+  #     - build-linux
+  #   steps:
+  #     - name: 🧾 Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         lfs: true
+  #         submodules: "recursive"
+  #         fetch-depth: 0 # So we can get all tags.
 
-      - name: Download macOS artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: macos-artifacts
-          path: ./addons/platform/builds/macos
+  #     - name: Download macOS artifacts
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: macos-artifacts
+  #         path: ./addons/platform/builds/macos
 
-      - name: Download Windows artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: windows-artifacts
-          path: ./addons/platform/builds/windows
+  #     - name: Download Windows artifacts
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: windows-artifacts
+  #         path: ./addons/platform/builds/windows
 
-      - name: Download Linux artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: linux-artifacts
-          path: ./addons/platform/builds/linux
+  #     - name: Download Linux artifacts
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: linux-artifacts
+  #         path: ./addons/platform/builds/linux
 
-      - name: Upload consolidated artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: platform
-          path: ./addons/platform
+  #     - name: Upload consolidated artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: platform
+  #         path: ./addons/platform
 
   create-release:
     runs-on: ubuntu-latest
     needs:
-      - consolidate-artifacts
+      # - consolidate-artifacts
       - build-for-nuget
     steps:
       - name: 🧾 Checkout
@@ -291,11 +291,11 @@ jobs:
           godot-version: 1.0.0
           bump: ${{ inputs.bump }}
 
-      - name: Download GDExtension artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: platform
-          path: ./platform
+      # - name: Download GDExtension artifacts
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: platform
+      #     path: ./platform
 
       - name: Download nuget package artifact
         uses: actions/download-artifact@v4
@@ -310,18 +310,29 @@ jobs:
           echo "package=$package" >> "$GITHUB_OUTPUT"
           echo "📦 Found nuget package: $package"
 
-      - name: ✨ Create Release
+      # - name: ✨ Create Release with GDExtension and Nuget Package
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GH_BASIC }}
+      #   run: |
+      #     zip -r ./platform.zip ./platform
+
+      #     version="${{ steps.next-version.outputs.version }}"
+
+      #     NUGET_PKG="${{ steps.package-path.outputs.package }}"
+
+      #     gh release create --title "v$version" --generate-notes "$version" \
+      #       ./platform.zip "$NUGET_PKG"
+
+      - name: ✨ Create Release with Nuget Package
         env:
           GITHUB_TOKEN: ${{ secrets.GH_BASIC }}
         run: |
-          zip -r ./platform.zip ./platform
-
           version="${{ steps.next-version.outputs.version }}"
 
           NUGET_PKG="${{ steps.package-path.outputs.package }}"
 
           gh release create --title "v$version" --generate-notes "$version" \
-            ./platform.zip "$NUGET_PKG"
+            "$NUGET_PKG"
 
       - uses: actions/setup-dotnet@v4
         name: 💽 Setup .NET SDK

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
       "preLaunchTask": "build",
       "program": "${env:GODOT}",
       "args": [],
-      "cwd": "${workspaceFolder}/sandbox/Chickensoft.Platform.Sandbox",
+      "cwd": "${workspaceFolder}/sandbox/Chickensoft.Platform.SandboxRef",
       "stopAtEntry": false,
       "console": "integratedTerminal"
     },
@@ -25,7 +25,7 @@
       "internalConsoleOptions": "openOnSessionStart",
       "pipeTransport": {
         "debuggerPath": "${extensionInstallFolder:muhammad-sammy.csharp}/.debugger/netcoredbg/netcoredbg",
-        "pipeCwd": "${workspaceFolder}/sandbox/Chickensoft.Platform.Sandbox",
+        "pipeCwd": "${workspaceFolder}/sandbox/Chickensoft.Platform.SandboxRef",
         "pipeProgram": "${env:GODOT}",
         "pipeArgs": [
           "--debug"

--- a/Chickensoft.PlatformExt/README.md
+++ b/Chickensoft.PlatformExt/README.md
@@ -1,0 +1,76 @@
+# Platform GDExtension
+
+This project was previously shipped as a GDExtension, but because [godot-dotnet] does not have regular releases, this project cannot be easily distributed as a GDExtension and kept up-to-date.
+
+Old documentation provided for reference below:
+
+## 📦 GDExtension Installation
+
+You can download the zip file from the releases. For a better experience, consider using [GodotEnv] to install and manage it as an addon in your project. In your addons.json file, place the following:
+
+```json
+{
+  "$schema": "https://chickensoft.games/schemas/addons.schema.json",
+  "addons": {
+    "platform": {
+      "source": "zip",
+      "subfolder": "platform",
+      "url": "https://github.com/chickensoft-games/Platform/releases/download/0.4.0/platform.zip"
+    }
+  }
+}
+```
+
+Then, run `godotenv addons install`. You should see a directory named `platform` in your project's `addons` directory.
+
+You can easily invoke the extension from GDScript:
+
+```gdscript
+func _ready() -> void:
+  var displays = Displays.new()
+  var scaleFactor = displays.GetDisplayScaleFactor(get_window())
+  print("scale factor: ", scaleFactor)
+```
+
+## 🛠️ Building the GDExtension
+
+.NET AOT compilation does not support cross-OS builds yet. You'll only be able to build a few variants on a single OS.
+
+You can use the included `build.sh` script to create the assemblies for your platform.
+
+```sh
+./build.sh macos
+./build.sh linux
+./build.sh windows
+```
+
+## 🤗 Contributing
+
+The GDExtension version of this uses the [godot-dotnet] C# GDExtension bindings that are still being actively developed. Since godot-dotnet isn't published yet, we've added a `nuget.config` file to the project which contains the nightly package feed.
+
+Note that you can enumerate all versions of godot-dotnet available for use by running:
+
+```sh
+nuget list -Source godot-dotnet -AllVersions -Prerelease
+```
+
+There is a Godot sandbox project in `sandbox/Chickensoft.Platform.Sandbox` that you can run to test the library manually on the platforms you have built for. **It has a readme with instructions on how to get it running.**
+
+- [godot-dotnet: Godot.Bindings](https://github.com/raulsntos/godot-dotnet/tree/master/src/Godot.Bindings)
+- [Godot: GDExtension C++ Example](https://docs.godotengine.org/en/stable/tutorials/scripting/gdextension/gdextension_cpp_example.html)
+
+As of right now, the `warning IL2104: Assembly 'Godot.Bindings' produced trim warnings` shown during build is a known issue. It doesn't prevent anything from working, however.
+
+## 🙋‍♀️ Open Questions
+
+Help wanted! We have a few outstanding open questions that we are seeking feedback on:
+
+- [godot-dotnet]: Can we have reloadable GDExtensions written in C#?
+- C#: Can we create native iOS libraries (XCFrameworks)?
+- C#: Can we create native android libraries? [It seems possible][native-android-libs].
+- Linux display scaling: it should be possible to implement display scale factor detection on linux if Godot does not provide an accurate scale factor. This could be done by detecting whether the environment is X11 or Wayland, and then invoking methods in libX11.so or libwayland-client.so, respectively.
+
+If you know the answer to any of these, please open an issue or reach out to us in Discord! We are eager to support more platforms and improve this project.
+
+[godot-dotnet]: https://github.com/raulsntos/godot-dotnet
+[native-android-libs]: https://github.com/jonathanpeppers/Android-NativeAOT/blob/main/DotNet/libdotnet.csproj

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🧩 Platform
 
-Platform-specific native extensions for Godot. This is distributed as a GDExtension that GDScript users can use, as well as a [nuget package] that C# scripting users can add to their projects.
+Platform-specific native extensions for Godot.
 
 ---
 
@@ -12,38 +12,13 @@ Platform-specific native extensions for Godot. This is distributed as a GDExtens
 
 ## ✅ Features
 
-Right now, this project simply provides a way to determine the actual scale factor of the display a Godot window is located on. Godot does not determine the actual scale factor and cannot provide enough information to determine it accurately, so we use various native API's to determine the true scale factor.
+Platform provides a way to determine the actual scale factor and native resolution of the display that a Godot window is located on. Godot does not determine the actual scale factor and native resolution reliably on Windows and macOS, so we use various native API's to determine the true scale factor.
 
-- ✅ Determine scale factor on macOS.
-- ✅ Determine scale factor on Windows.
+- ✅ Determine scale factor and native resolution on macOS.
+- ✅ Determine scale factor and native resolution on Windows.
 
-## 📦 GDExtension Installation
-
-You can download the zip file from the releases. For a better experience, consider using [GodotEnv] to install and manage it as an addon in your project. In your addons.json file, place the following:
-
-```json
-{
-  "$schema": "https://chickensoft.games/schemas/addons.schema.json",
-  "addons": {
-    "platform": {
-      "source": "zip",
-      "subfolder": "platform",
-      "url": "https://github.com/chickensoft-games/Platform/releases/download/0.4.0/platform.zip"
-    }
-  }
-}
-```
-
-Then, run `godotenv addons install`. You should see a directory named `platform` in your project's `addons` directory.
-
-You can easily invoke the extension from GDScript:
-
-```gdscript
-func _ready() -> void:
-  var displays = Displays.new()
-  var scaleFactor = displays.GetDisplayScaleFactor(get_window())
-  print("scale factor: ", scaleFactor)
-```
+> [!NOTE]
+> You may be more interested in using [GameTools], which uses this project to provide a high-level display-agnostic scaling API to help your game or app look consistent and scale correctly in multi-monitor mixed-DPI environments.
 
 ## 📦 Nuget Package Installation
 
@@ -55,22 +30,14 @@ Then, use it like so:
 
 ```csharp
 using Chickensoft.Platform;
-var systemScale = Displays.Singleton.GetDisplayScaleFactor(window);
+
+// Use Win32 or CoreGraphics to get the display's actual resolution.
+var resolution = Displays.Singleton.GetNativeResolution(window);
+// Use Win32 or CoreGraphics to determine the display's actual scale factor.
+var scale = Displays.Singleton.GetDisplayScaleFactor(window);
 ```
 
 That's it!
-
-## 🛠️ Building the GDExtension
-
-.NET AOT compilation does not support cross-OS builds yet. You'll only be able to build a few variants on a single OS.
-
-You can use the included `build.sh` script to create the assemblies for your platform.
-
-```sh
-./build.sh macos
-./build.sh linux
-./build.sh windows
-```
 
 ## 🛠️ Building the Nuget Package
 
@@ -81,39 +48,11 @@ cd Chickensoft.Platform
 dotnet build
 ```
 
-## 🤗 Contributing
-
-The GDExtension version of this uses the [godot-dotnet] C# GDExtension bindings that are still being actively developed. Since godot-dotnet isn't published yet, we've added a `nuget.config` file to the project which contains the nightly package feed.
-
-Note that you can enumerate all versions of godot-dotnet available for use by running:
-
-```sh
-nuget list -Source godot-dotnet -AllVersions -Prerelease
-```
-
 It helps if you have read some of the relevant documentation:
 
 - [Microsoft: Building Native Libraries with NativeAOT](https://github.com/dotnet/samples/blob/main/core/nativeaot/NativeLibrary/README.md)
-- [godot-dotnet: Godot.Bindings](https://github.com/raulsntos/godot-dotnet/tree/master/src/Godot.Bindings)
-- [Godot: GDExtension C++ Example](https://docs.godotengine.org/en/stable/tutorials/scripting/gdextension/gdextension_cpp_example.html)
 - [Source generation for platform invokes (p/invoke)](https://learn.microsoft.com/en-us/dotnet/standard/native-interop/pinvoke-source-generation)
 
-As of right now, the `warning IL2104: Assembly 'Godot.Bindings' produced trim warnings` shown during build is a known issue. It doesn't prevent anything from working, however.
+There is a Godot sandbox project in `sandbox/Chickensoft.Platform.SandboxRef` that you can run to test the library manually.
 
-There is a Godot sandbox project in `sandbox/Chickensoft.Platform.Sandbox` that you can run to test the library manually on the platforms you have built for. **It has a readme with instructions on how to get it running.**
-
-## 🙋‍♀️ Open Questions
-
-Help wanted! We have a few outstanding open questions that we are seeking feedback on:
-
-- [godot-dotnet]: Can we have reloadable GDExtensions written in C#?
-- C#: Can we create native iOS libraries (XCFrameworks)?
-- C#: Can we create native android libraries? [It seems possible][native-android-libs].
-- Linux display scaling: it should be possible to implement display scale factor detection on linux if Godot does not provide an accurate scale factor. This could be done by detecting whether the environment is X11 or Wayland, and then invoking methods in libX11.so or libwayland-client.so, respectively.
-
-If you know the answer to any of these, please open an issue or reach out to us in Discord! We are eager to support more platforms and improve this project.
-
-[godot-dotnet]: https://github.com/raulsntos/godot-dotnet
-[native-android-libs]: https://github.com/jonathanpeppers/Android-NativeAOT/blob/main/DotNet/libdotnet.csproj
-[GodotEnv]: https://github.com/chickensoft-games/GodotEnv
-[nuget package]: https://www.nuget.org/packages/Chickensoft.Platform/
+[GameTools]: https://github.com/chickensoft-games/GameTools

--- a/sandbox/Chickensoft.Platform.SandboxRef/src/Main.cs
+++ b/sandbox/Chickensoft.Platform.SandboxRef/src/Main.cs
@@ -22,9 +22,9 @@ public partial class Main : Control {
       ProjectSettings.GetSetting("display/window/size/viewport_height").AsInt32()
     );
     // Use Win32 or CoreGraphics to get the display's actual resolution.
-    var resolution = displays.GetNativeResolution(window);
+    var resolution = Displays.Singleton.GetNativeResolution(window);
     // Use Win32 or CoreGraphics to determine the display's actual scale factor.
-    var monitorScale = displays.GetDisplayScaleFactor(window);
+    var monitorScale = Displays.Singleton.GetDisplayScaleFactor(window);
     // Godot reports Windows' system scale factor, which may be different from
     // the monitor's scale factor since Godot does not opt-in to per-monitor DPI
     // awareness on Windows.


### PR DESCRIPTION
We cannot ship this project as a GDExtension since godot-dotnet is not kept up-to-date. I've kept the infrastructure in place to do so in case this changes someday.